### PR TITLE
Moved _responsive.less to the bottom of the includes to avoid overriding responsive styles

### DIFF
--- a/vendor/styles/bootstrap/bootstrap.less
+++ b/vendor/styles/bootstrap/bootstrap.less
@@ -26,9 +26,6 @@
 @import "_forms.less";
 @import "_tables.less";
 
-// Responsive CSS
-@import "_responsive.less";
-
 // Components: common
 @import "_sprites.less";
 @import "_dropdowns.less";
@@ -64,3 +61,6 @@
 
 // Utility classes
 @import "_utilities.less"; // Has to be last to override when necessary
+
+// Responsive CSS
+@import "_responsive.less";


### PR DESCRIPTION
Referencing this issue: https://github.com/twitter/bootstrap/issues/1842 where including responsive.less after "Base CSS" was causing issues with styling. Placing the @import "_responsive.less" at the bottom of bootstrap.less resolves various sizing problems (specifically, in my experience, with the navbar).
